### PR TITLE
Fix layout wrapper for Next.js

### DIFF
--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -44,10 +44,10 @@ export default async function RootLayout({
 
   return (
     <html lang={locale}>
-      <AppProvider>
-        <body
-          className={`${geistSans.variable} ${geistMono.variable} antialiased`}
-        >
+      <body
+        className={`${geistSans.variable} ${geistMono.variable} antialiased`}
+      >
+        <AppProvider>
           <NextIntlClientProvider locale={locale} messages={messages}>
             <div className="absolute top-4 right-4">
               <LanguageSwitcher />
@@ -57,8 +57,8 @@ export default async function RootLayout({
               <Toaster />
             </Providers>
           </NextIntlClientProvider>
-        </body>
-      </AppProvider>
+        </AppProvider>
+      </body>
     </html>
   );
 }


### PR DESCRIPTION
## Summary
- fix Next.js root layout to have `<html>` and `<body>` wrapper elements as required

## Testing
- `npm run build` *(fails: Could not find a declaration file for module 'bcryptjs')*

------
https://chatgpt.com/codex/tasks/task_e_685713780db88322bad5eade34c334a9