### PR TITLE
Fix layout params usage

### DIFF
--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -28,11 +28,12 @@ export const metadata: Metadata = {
 
 export default async function RootLayout({
   children,
-  params: { locale },
+  params,
 }: Readonly<{
   children: React.ReactNode;
-  params: { locale: string };
+  params: Promise<{ locale: string }>;
 }>) {
+  const { locale } = await params;
   await ensureDefaultAdmin()
   const session = await getSession()
   let messages


### PR DESCRIPTION
## Summary
- await params in RootLayout to support Next.js 15 dynamic APIs

## Testing
- `bun run lint` *(fails: '@typescript-eslint/no-explicit-any' and other lint errors)*
- `bun run test` *(fails: no `test` script found)*

------
https://chatgpt.com/codex/tasks/task_e_6857152f591083229bc1a423af36489f