### PR TITLE
Add embedded map to contacts page

### DIFF
--- a/src/components/home/Contacts.tsx
+++ b/src/components/home/Contacts.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import BaseContainer from "@/components/BaseContainer";
+import Map from "@/components/home/Map";
 
 
 export default function Contacts() {
@@ -20,6 +21,9 @@ export default function Contacts() {
                 +996 557‑31‑31‑14
               </a>
             </p>
+          </div>
+          <div className="h-72 lg:h-96">
+            <Map />
           </div>
         </div>
       </BaseContainer>

--- a/src/components/home/Map.tsx
+++ b/src/components/home/Map.tsx
@@ -1,0 +1,14 @@
+import React from "react";
+
+export default function Map() {
+  return (
+    <div className="w-full h-full rounded-lg overflow-hidden shadow-lg">
+      <iframe
+        title="Карта расположения"
+        src="https://www.openstreetmap.org/export/embed.html?bbox=74.6160,42.8580,74.6178,42.8592&layer=mapnik&marker=42.8585,74.6169"
+        className="w-full h-full border-0"
+        allowFullScreen
+      />
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add `Map` component with OpenStreetMap iframe
- show map on the contacts section

## Testing
- `npm install`
- `npm run lint` *(fails: Unexpected any and other lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_6859539030348322b95ac9933996bfda