### PR TITLE
Fix category page query defaults

### DIFF
--- a/src/app/admin/categories/page.tsx
+++ b/src/app/admin/categories/page.tsx
@@ -10,7 +10,7 @@ import getCategoriesAction from "@/actions/dashboard/getCategoriesAction";
 import deleteCategoryAction from "@/actions/dashboard/deleteCategoryAction";
 
 const CategoriesPage = async ({ searchParams }: SearchParams) => {
-  const { page = 1, perPage = 5 } = await searchParams;
+  const { page = "1", perPage = "5" } = await searchParams;
   const { items, totalItemsLength } = await getCategoriesAction(
     Number(page),
     Number(perPage),


### PR DESCRIPTION
## Summary
- fix CategoriesPage query default values to be strings

## Testing
- `npx tsc -p tsconfig.json --noEmit` *(fails: Cannot find module 'react' or its corresponding type declarations)*
- `npx next build` *(fails: needs to install next)*

------
https://chatgpt.com/codex/tasks/task_e_6859b4cb00f88322818c1683e86b3b14