### PR TITLE
fix: fallback nextauth secret

### DIFF
--- a/src/auth.ts
+++ b/src/auth.ts
@@ -3,9 +3,15 @@ import CredentialsProvider from "next-auth/providers/credentials";
 import { getUserByEmail } from "./lib/dbUtils";
 import bcrypt from "bcryptjs";
 import { connectToDatabase } from "@/lib/dbConnect";
+import { randomBytes } from "crypto";
+
+const authSecret =
+  process.env.NEXTAUTH_SECRET ||
+  process.env.AUTH_SECRET ||
+  randomBytes(32).toString("hex");
 
 export const authOptions: NextAuthOptions = {
-  secret: process.env.NEXTAUTH_SECRET,
+  secret: authSecret,
   providers: [
     CredentialsProvider({
       name: "Credentials",
@@ -31,7 +37,13 @@ export const authOptions: NextAuthOptions = {
             name: user.name,
             image: user.image,
             role: user.role,
-          } as any;
+          } as {
+            id: string;
+            email: string;
+            name: string;
+            image?: string;
+            role: string;
+          };
         } catch (error) {
           console.error("Error during credentials authorize", error);
           return null;


### PR DESCRIPTION
## Summary
- generate fallback NextAuth secret when env vars missing
- type user object returned from CredentialsProvider

## Testing
- `npm run lint` *(fails: Unexpected any, etc.)*
- `npm run build`
- `npm run start -- -p 3100` & `curl -s -D - http://localhost:3100/ | head`


------
https://chatgpt.com/codex/tasks/task_e_68c288284fd08322994df176f3b613fd