### PR TITLE
Fix auth imports for favorites API routes

### DIFF
--- a/src/app/api/favorites/clear/route.ts
+++ b/src/app/api/favorites/clear/route.ts
@@ -1,11 +1,11 @@
-import { NextRequest, NextResponse } from 'next/server';
+import { NextResponse } from 'next/server';
 import { getServerSession } from 'next-auth';
 import { connectToDatabase } from '@/lib/dbConnect';
-import { Favorite } from '@/models/Favorite';
-import { authOptions } from '@/lib/auth';
+import Favorite from '@/models/Favorite';
+import { authOptions } from '@/auth';
 
 // DELETE - Очистить все избранные товары пользователя
-export async function DELETE(request: NextRequest) {
+export async function DELETE() {
   try {
     const session = await getServerSession(authOptions);
     

--- a/src/app/api/favorites/route.ts
+++ b/src/app/api/favorites/route.ts
@@ -1,11 +1,11 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { getServerSession } from 'next-auth';
 import { connectToDatabase } from '@/lib/dbConnect';
-import { Favorite } from '@/models/Favorite';
-import { Product } from '@/models/Product';
-import { authOptions } from '@/lib/auth';
+import Favorite from '@/models/Favorite';
+import Product from '@/models/Product';
+import { authOptions } from '@/auth';
 // GET - Получить список избранных товаров пользователя
-export async function GET(request: NextRequest) {
+export async function GET() {
   try {
     const session = await getServerSession(authOptions);
     


### PR DESCRIPTION
## Summary
- use updated `auth` module in favorites API endpoints
- switch to default exports for `Favorite` and `Product` models
- clean up unused parameters in favorites routes

## Testing
- `pnpm lint` *(fails: Unexpected any, no-html-link-for-pages and unused-vars in existing files)*
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_68c3363bd9988322931c1c738235685c