### PR TITLE
Handle missing MongoDB configuration for dashboard metrics API

### DIFF
--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -1,1 +1,8 @@
-export { authOptions } from '../auth';
+import { getServerSession } from 'next-auth';
+import { authOptions } from '../auth';
+
+export { authOptions };
+
+export function auth() {
+  return getServerSession(authOptions);
+}


### PR DESCRIPTION
## Summary
- add a reusable auth() helper that wraps getServerSession so dashboard APIs can validate sessions
- make the MongoDB helper lazily establish connections and avoid throwing during module load when the URI is missing
- guard the dashboard metrics API so it returns empty data when MongoDB is not configured instead of crashing

## Testing
- pnpm lint *(fails: numerous pre-existing lint violations throughout the project)*
- pnpm build *(fails: prerendering /admin/cache requires a NextAuth session during build)*

------
https://chatgpt.com/codex/tasks/task_e_68cc01dc5f7c83228c897b81136223b9