### PR TITLE
Fix admin analytics build error

### DIFF
--- a/src/app/admin/layout.tsx
+++ b/src/app/admin/layout.tsx
@@ -1,22 +1,30 @@
 import { ReactNode } from "react";
+import { getServerSession } from 'next-auth';
+
 import AdaptiveLayout from "@/components/dashboard/AdaptiveLayout";
+import Providers from '@/app/providers';
+import { authOptions } from '@/auth';
+import { defaultLocale } from '@/lib/i18n/config';
 import { I18nProvider } from '@/lib/i18n/provider';
 import { getDictionary } from '@/lib/i18n/server';
-import { defaultLocale } from '@/lib/i18n/config';
 
 export default async function AdminLayout({
   children,
 }: Readonly<{
   children: ReactNode;
 }>) {
-  // Load dictionary for default locale (ru)
-  const dictionary = await getDictionary(defaultLocale);
-  
+  const [dictionary, session] = await Promise.all([
+    getDictionary(defaultLocale),
+    getServerSession(authOptions),
+  ]);
+
   return (
-    <I18nProvider locale={defaultLocale} dictionary={dictionary}>
-      <AdaptiveLayout userRole="admin">
-        {children}
-      </AdaptiveLayout>
-    </I18nProvider>
+    <Providers session={session}>
+      <I18nProvider locale={defaultLocale} dictionary={dictionary}>
+        <AdaptiveLayout userRole="admin">
+          {children}
+        </AdaptiveLayout>
+      </I18nProvider>
+    </Providers>
   );
 }


### PR DESCRIPTION
## Summary
- wrap the admin layout with the shared Providers component so useSession has context during prerendering
- load the admin dictionary and server session concurrently before rendering the adaptive layout

## Testing
- pnpm run build

------
https://chatgpt.com/codex/tasks/task_e_68cc04713764832290d982f86c5ec55e