### PR TITLE
Gracefully handle missing Saleor configuration during builds

### DIFF
--- a/apps/storefront/src/app/[locale]/(main)/account/payment-methods/page.tsx
+++ b/apps/storefront/src/app/[locale]/(main)/account/payment-methods/page.tsx
@@ -1,6 +1,5 @@
-import { type ReactNode } from "react";
-
 import { getTranslations } from "next-intl/server";
+import { type ReactNode } from "react";
 
 import { type PaymentMethod } from "@nimara/domain/objects/Payment";
 

--- a/apps/storefront/src/envs/client.ts
+++ b/apps/storefront/src/envs/client.ts
@@ -20,6 +20,9 @@ const optionalString = () =>
       .optional(),
   );
 
+const FALLBACK_SALEOR_API_URL = "https://demo.saleor.io/graphql/";
+const FALLBACK_DEFAULT_CHANNEL = "default-channel";
+
 const schema = z.object({
   NEXT_PUBLIC_CMS_SERVICE: sanitizeEnv(
     z.enum(["SALEOR", "BUTTER_CMS"]).default("SALEOR"),
@@ -33,7 +36,9 @@ const schema = z.object({
       .default("LOCAL"),
   ),
   NEXT_PUBLIC_BUTTER_CMS_API_KEY: optionalString(),
-  NEXT_PUBLIC_DEFAULT_CHANNEL: sanitizeEnv(z.string().trim()),
+  NEXT_PUBLIC_DEFAULT_CHANNEL: sanitizeEnv(
+    z.string().trim().default(FALLBACK_DEFAULT_CHANNEL),
+  ),
   NEXT_PUBLIC_DEFAULT_EMAIL: sanitizeEnv(
     z
       .string()
@@ -47,7 +52,9 @@ const schema = z.object({
       .trim()
       .default("Nimara Storefront"),
   ),
-  NEXT_PUBLIC_SALEOR_API_URL: sanitizeEnv(z.string().url().trim()),
+  NEXT_PUBLIC_SALEOR_API_URL: sanitizeEnv(
+    z.string().url().trim().default(FALLBACK_SALEOR_API_URL),
+  ),
   NEXT_PUBLIC_STOREFRONT_URL: sanitizeEnv(z.string().url().trim()),
   PAYMENT_APP_ID: optionalString(),
   STRIPE_PUBLIC_KEY: optionalString(),
@@ -59,6 +66,21 @@ const schema = z.object({
     z.string().trim().min(1).default("YOUR_API_KEY"),
   ),
 });
+
+const warnIfMissing = (envName: string, message: string) => {
+  if (!process.env[envName]) {
+    console.warn(`[storefront] ${message}`);
+  }
+};
+
+warnIfMissing(
+  "NEXT_PUBLIC_DEFAULT_CHANNEL",
+  `NEXT_PUBLIC_DEFAULT_CHANNEL is not defined. Using "${FALLBACK_DEFAULT_CHANNEL}" as a fallback channel slug.`,
+);
+warnIfMissing(
+  "NEXT_PUBLIC_SALEOR_API_URL",
+  "NEXT_PUBLIC_SALEOR_API_URL is not defined. Using demo Saleor endpoint for build-time configuration.",
+);
 
 export const clientEnvs = schema.parse({
   NEXT_PUBLIC_CMS_SERVICE: process.env.NEXT_PUBLIC_CMS_SERVICE,

--- a/apps/storefront/src/services/payment.ts
+++ b/apps/storefront/src/services/payment.ts
@@ -1,6 +1,6 @@
 import { err } from "@nimara/domain/objects/Result";
-import { type StripePaymentService } from "@nimara/infrastructure/payment/providers";
 import { type Logger } from "@nimara/infrastructure/logging/types";
+import { type StripePaymentService } from "@nimara/infrastructure/payment/providers";
 
 import { clientEnvs } from "@/envs/client";
 import { serverEnvs } from "@/envs/server";
@@ -40,7 +40,7 @@ const createDisabledResult = () =>
 
 const createDisabledPaymentService = (logger: Logger): StripePaymentService => {
   const warn = (operation: string) =>
-    logger.warn(DISABLED_MESSAGE, {
+    logger.warning(DISABLED_MESSAGE, {
       operation,
       missingKeys: missingPaymentConfigKeys,
     });
@@ -124,7 +124,7 @@ export const getPaymentService = async (): Promise<StripePaymentService> => {
   const storefrontLogger = await getStorefrontLogger();
 
   if (!isPaymentServiceConfigured) {
-    storefrontLogger.warn(DISABLED_MESSAGE, {
+    storefrontLogger.warning(DISABLED_MESSAGE, {
       missingKeys: missingPaymentConfigKeys,
     });
 

--- a/apps/stripe/src/config.ts
+++ b/apps/stripe/src/config.ts
@@ -7,29 +7,62 @@ import packageJson from "../package.json";
 const configSchema = z.object({
   NAME: z.string().default(packageJson.name),
   VERSION: z.string().default(packageJson.version),
-  ENVIRONMENT: z.string(),
+  ENVIRONMENT: z.string().default("LOCAL"),
   SALEOR_URL: z.string().url(),
   SALEOR_DOMAIN: z.string(),
   FETCH_TIMEOUT: z
     .number()
     .default(10000)
     .describe("Fetch timeout in milliseconds."),
-  VERCEL_ACCESS_TOKEN: z.string().describe("Vercel access token."),
-  VERCEL_TEAM_ID: z.string().describe("Your Vercel Team ID."),
-  VERCEL_EDGE_CONFIG_ID: z.string().describe("Edge config database ID."),
+  VERCEL_ACCESS_TOKEN: z
+    .string()
+    .default("")
+    .describe("Vercel access token."),
+  VERCEL_TEAM_ID: z
+    .string()
+    .default("")
+    .describe("Your Vercel Team ID."),
+  VERCEL_EDGE_CONFIG_ID: z
+    .string()
+    .default("")
+    .describe("Edge config database ID."),
   CONFIG_KEY: z
     .string()
     .describe("Config provider key.")
     .default("nimara-config"),
 });
 
+const FALLBACK_SALEOR_API_URL = "https://demo.saleor.io/graphql/";
+
+const resolvedSaleorApiUrl =
+  process.env.NEXT_PUBLIC_SALEOR_API_URL ?? FALLBACK_SALEOR_API_URL;
+
+if (!process.env.NEXT_PUBLIC_SALEOR_API_URL) {
+  console.warn(
+    "[stripe] NEXT_PUBLIC_SALEOR_API_URL is not defined. Using demo Saleor endpoint for build-time configuration.",
+  );
+}
+
+const warnIfMissing = (envName: string) => {
+  if (!process.env[envName]) {
+    console.warn(`[stripe] ${envName} is not defined. Using empty fallback value for build-time configuration.`);
+  }
+};
+
+warnIfMissing("VERCEL_ACCESS_TOKEN");
+warnIfMissing("VERCEL_TEAM_ID");
+warnIfMissing("VERCEL_EDGE_CONFIG_ID");
+warnIfMissing("NEXT_PUBLIC_ENVIRONMENT");
+
+const saleorUrl = new URL(resolvedSaleorApiUrl);
+
 const parsed = prepareConfig({
   name: "App",
   schema: configSchema,
   input: {
-    ENVIRONMENT: process.env.NEXT_PUBLIC_ENVIRONMENT,
-    SALEOR_URL: new URL(process.env.NEXT_PUBLIC_SALEOR_API_URL ?? "").origin,
-    SALEOR_DOMAIN: new URL(process.env.NEXT_PUBLIC_SALEOR_API_URL ?? "").host,
+    ENVIRONMENT: process.env.NEXT_PUBLIC_ENVIRONMENT ?? "LOCAL",
+    SALEOR_URL: saleorUrl.origin,
+    SALEOR_DOMAIN: saleorUrl.host,
   },
   serverOnly: true,
 });

--- a/packages/codegen/package.json
+++ b/packages/codegen/package.json
@@ -2,7 +2,7 @@
   "name": "@nimara/codegen",
   "version": "1.0.0",
   "scripts": {
-    "codegen:saleor": "graphql-codegen --config ./codegen.ts --project saleor",
+    "codegen:saleor": "node ./scripts/run-codegen.cjs",
     "codegen": "pnpm codegen:saleor"
   },
   "devDependencies": {

--- a/packages/codegen/scripts/run-codegen.cjs
+++ b/packages/codegen/scripts/run-codegen.cjs
@@ -1,0 +1,28 @@
+#!/usr/bin/env node
+const { spawn } = require("node:child_process");
+const path = require("node:path");
+
+const schemaUrl = process.env.NEXT_PUBLIC_SALEOR_API_URL;
+
+if (!schemaUrl) {
+  console.warn(
+    "[codegen] NEXT_PUBLIC_SALEOR_API_URL is not defined. Skipping Saleor GraphQL code generation and using existing artifacts.",
+  );
+  process.exit(0);
+}
+
+const codegenBin = require.resolve("@graphql-codegen/cli/bin.js");
+const configPath = path.join(__dirname, "..", "codegen.ts");
+
+const child = spawn(process.execPath, [codegenBin, "--config", configPath, "--project", "saleor"], {
+  stdio: "inherit",
+});
+
+child.on("exit", (code) => {
+  process.exit(code ?? 0);
+});
+
+child.on("error", (error) => {
+  console.error("[codegen] Failed to run GraphQL code generator:", error);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- add a guarded codegen runner that skips generation when the Saleor API URL is unset
- provide build-time fallbacks for required Stripe and Storefront Saleor environment variables
- update storefront logging to match the Logger interface and satisfy lint import ordering

## Testing
- pnpm run build

------
https://chatgpt.com/codex/tasks/task_e_68e3a444569083229f9313e9accc0d70