### PR TITLE
Ensure start pipeline builds storefront before running

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -49,7 +49,8 @@
       "dependsOn": ["^lint:staged"]
     },
     "start": {
-      "dependsOn": ["^codegen", "^start"]
+      "dependsOn": ["build", "^codegen", "^build", "^start"],
+      "outputs": []
     },
     "test": {},
     "test:watch": {


### PR DESCRIPTION
## Summary
- ensure the Turborepo `start` task depends on the package build so production artifacts exist before `next start`
- disable caching for the `start` task to avoid relying on missing build outputs

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e3af875f108322927fad46b1c85a4e