### PR TITLE
Fix Vercel build by copying storefront Next.js output to root

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   },
   "scripts": {
     "build": "dotenv -- turbo run build",
+    "postbuild": "node ./scripts/postbuild-link-storefront.mjs",
     "build:storefront": "pnpm run build --filter=storefront",
     "build:stripe": "pnpm run build --filter=stripe",
     "build:docs": "pnpm run build --filter=docs",

--- a/scripts/postbuild-link-storefront.mjs
+++ b/scripts/postbuild-link-storefront.mjs
@@ -1,0 +1,24 @@
+import { cpSync, existsSync, rmSync, statSync } from "node:fs";
+import { join, relative } from "node:path";
+
+const repoRoot = process.cwd();
+const storefrontBuildDir = join(repoRoot, "apps", "storefront", ".next");
+const rootNextDir = join(repoRoot, ".next");
+
+if (!existsSync(storefrontBuildDir) || !statSync(storefrontBuildDir, { throwIfNoEntry: false })?.isDirectory()) {
+  console.error(
+    `Expected Next.js build output at ${relative(repoRoot, storefrontBuildDir)}, but it was not found. ` +
+      "Ensure that the storefront app build has completed successfully before running this script."
+  );
+  process.exit(1);
+}
+
+if (existsSync(rootNextDir)) {
+  rmSync(rootNextDir, { recursive: true, force: true });
+}
+
+cpSync(storefrontBuildDir, rootNextDir, { recursive: true });
+
+console.log(
+  `Copied storefront build output from ${relative(repoRoot, storefrontBuildDir)} to ${relative(repoRoot, rootNextDir)} for Vercel deployment.`
+);


### PR DESCRIPTION
## Summary
- add a root postbuild step that prepares the storefront Next.js output for Vercel
- implement a helper script that copies the storefront .next directory into the repository root after building

## Testing
- pnpm run build

------
https://chatgpt.com/codex/tasks/task_e_68e3b2935c848322a69a5ad02cf09fa7