### PR TITLE
Fix postbuild symlink target

### DIFF
--- a/scripts/postbuild-link-storefront.mjs
+++ b/scripts/postbuild-link-storefront.mjs
@@ -19,8 +19,13 @@ if (existsSync(rootNextDir)) {
 
 const symlinkType = process.platform === "win32" ? "junction" : "dir";
 
+const rootNextDirParent = join(rootNextDir, "..");
+const symlinkTarget = symlinkType === "junction"
+  ? storefrontBuildDir
+  : relative(rootNextDirParent, storefrontBuildDir);
+
 try {
-  symlinkSync(storefrontBuildDir, rootNextDir, symlinkType);
+  symlinkSync(symlinkTarget, rootNextDir, symlinkType);
 
   console.log(
     `Linked storefront build output from ${relative(repoRoot, storefrontBuildDir)} to ${relative(


### PR DESCRIPTION
## Summary
- create relative symlink when linking the storefront build output into the repo root to avoid absolute paths on deployment
- fall back to the previous absolute path only when running on Windows junctions

## Testing
- pnpm run build

------
https://chatgpt.com/codex/tasks/task_e_68e3ba8d509c8322a9f45d1a2d6a5298