### PR TITLE
Handle missing OpenTelemetry context file

### DIFF
--- a/apps/storefront/src/instrumentation.ts
+++ b/apps/storefront/src/instrumentation.ts
@@ -1,14 +1,61 @@
+type NodeError = NodeJS.ErrnoException & { code?: string };
+
+const isMissingOtelContextFileError = (error: unknown): error is NodeError => {
+  if (!error || typeof error !== "object") {
+    return false;
+  }
+
+  const err = error as NodeError;
+
+  return (
+    err.code === "ENOENT" &&
+    typeof err.message === "string" &&
+    err.message.includes("@opentelemetry/api/build/src/api/context")
+  );
+};
+
+const isModuleNotFoundError = (error: unknown): error is NodeError => {
+  if (!error || typeof error !== "object") {
+    return false;
+  }
+
+  const err = error as NodeError;
+
+  return err.code === "MODULE_NOT_FOUND" || err.code === "ERR_MODULE_NOT_FOUND";
+};
+
 export async function register() {
   if (process.env.OTEL_SERVICE_NAME) {
     // By making this path dynamic, we ensure that bundler
     // does not include the OpenTelemetry package in the bundle.
     const otelPath = "@vercel/otel";
-    const { registerOTel } = await import(otelPath);
 
-    registerOTel({
-      serviceName: process.env.OTEL_SERVICE_NAME,
-    });
-    console.log("OpenTelemetry registered.");
+    try {
+      const { registerOTel } = await import(otelPath);
+
+      try {
+        registerOTel({
+          serviceName: process.env.OTEL_SERVICE_NAME,
+        });
+        console.log("OpenTelemetry registered.");
+      } catch (error) {
+        if (isMissingOtelContextFileError(error)) {
+          console.warn(
+            "OpenTelemetry registration skipped: context API file was not found in node_modules. Ensure the project is built with access to @opentelemetry/api, or remove OTEL_SERVICE_NAME to disable instrumentation.",
+          );
+        } else {
+          throw error;
+        }
+      }
+    } catch (error) {
+      if (isModuleNotFoundError(error)) {
+        console.warn(
+          "OpenTelemetry package '@vercel/otel' could not be resolved. Ensure it is installed or remove OTEL_SERVICE_NAME to disable instrumentation.",
+        );
+      } else {
+        throw error;
+      }
+    }
   }
 
   if (process.env.SENTRY_DSN) {


### PR DESCRIPTION
## Summary
- guard the storefront instrumentation setup against missing OpenTelemetry context files
- add module resolution checks so OTEL registration failure surfaces as a warning instead of a crash

## Testing
- pnpm --filter=storefront lint

------
https://chatgpt.com/codex/tasks/task_e_68e3bde56b048322bb807194c708acb0