### PR TITLE
fix: avoid absolute node_modules symlink

### DIFF
--- a/scripts/postbuild-link-storefront.mjs
+++ b/scripts/postbuild-link-storefront.mjs
@@ -33,12 +33,12 @@ if (shouldCopyOnVercel) {
   if (process.platform !== "win32") {
     const storefrontRoot = join(repoRoot, "apps", "storefront");
 
+    // Only mirror workspace directories that the Vercel bundler expects to
+    // live at the repository root. Avoid linking the top-level node_modules as
+    // an absolute path (e.g. "/node_modules"), because the bundler rejects
+    // assets that resolve outside of the project directory when tracing
+    // serverless functions.
     const symlinkMap = [
-      {
-        linkPath: "/node_modules",
-        targetPath: join(repoRoot, "node_modules"),
-        logMessage: "Linked /node_modules to project node_modules for Vercel bundler compatibility.",
-      },
       {
         linkPath: join(repoRoot, "src"),
         targetPath: join(storefrontRoot, "src"),


### PR DESCRIPTION
## Summary
- stop creating an absolute /node_modules symlink during the Vercel postbuild step
- document why only selected workspace directories are mirrored for the bundler

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e3f7fe1c108322a8da308a8cfd6e12