### PR TITLE
Fix Vercel postbuild directory mirroring

### DIFF
--- a/scripts/postbuild-link-storefront.mjs
+++ b/scripts/postbuild-link-storefront.mjs
@@ -64,13 +64,26 @@ if (shouldCopyOnVercel) {
           throwIfNoEntry: false,
         });
 
-        if (targetExists && !linkStats) {
-          symlinkSync(targetPath, linkPath, symlinkType);
-          console.log(logMessage);
+        if (!targetExists) {
+          return;
         }
+
+        if (linkStats) {
+          if (linkStats.isSymbolicLink() || linkStats.isDirectory()) {
+            rmSync(linkPath, { recursive: true, force: true });
+          } else {
+            console.warn(
+              `Found existing non-directory at ${linkPath}. Skipping mirroring for Vercel bundler compatibility.`
+            );
+            return;
+          }
+        }
+
+        cpSync(targetPath, linkPath, { recursive: true });
+        console.log(logMessage.replace("Linked", "Copied"));
       } catch (error) {
         console.warn(
-          `Failed to prepare symlink at ${linkPath} pointing to ${targetPath}.`
+          `Failed to mirror directory at ${linkPath} from ${targetPath}.`
             + " Vercel bundler may fail if this resource is required during tracing.",
           error,
         );


### PR DESCRIPTION
## Summary
- copy the storefront src/public/messages directories into the repo root during Vercel builds instead of creating symlinks
- add safety checks and clearer logging when mirroring directories for the Vercel bundler

## Testing
- not run (script change only)


------
https://chatgpt.com/codex/tasks/task_e_68e3fa0fc5b88322bf49d1346b1ffd08