### PR TITLE
Fix postbuild copy to preserve symlinks

### DIFF
--- a/scripts/postbuild-link-storefront.mjs
+++ b/scripts/postbuild-link-storefront.mjs
@@ -19,9 +19,10 @@ if (existsSync(rootNextDir)) {
 
 const shouldCopyOnVercel = process.env.VERCEL === "1";
 const symlinkType = process.platform === "win32" ? "junction" : "dir";
+const cpOptions = { recursive: true, dereference: false };
 
 if (shouldCopyOnVercel) {
-  cpSync(storefrontBuildDir, rootNextDir, { recursive: true });
+  cpSync(storefrontBuildDir, rootNextDir, cpOptions);
 
   console.log(
     `Copied storefront build output from ${relative(repoRoot, storefrontBuildDir)} to ${relative(
@@ -111,7 +112,7 @@ if (shouldCopyOnVercel) {
       error
     );
 
-    cpSync(storefrontBuildDir, rootNextDir, { recursive: true });
+    cpSync(storefrontBuildDir, rootNextDir, cpOptions);
 
     console.log(
       `Copied storefront build output from ${relative(repoRoot, storefrontBuildDir)} to ${relative(


### PR DESCRIPTION
## Summary
- preserve symbolic links when copying the storefront build output during the postbuild step to avoid missing dependency errors on Vercel

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e3fba99dc8832286d62ca77ea2e470